### PR TITLE
minor patch to add resuable workflows and only publish on merge

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,62 +1,26 @@
 name: Build and Publish Docker Image
 
 on:
-  push:
-    branches:
-      - main
-    tags:
-      - 'v*.*.*'
   pull_request:
-    branches:
-      - main
+    branches: [main]
+    types: [closed]
   workflow_dispatch:
 
-env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
-
 jobs:
-  build-and-push:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Log in to GitHub Container Registry
-        if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Extract metadata for Docker
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          tags: |
-            type=ref,event=branch
-            type=ref,event=pr
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
-            type=sha
-
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          platforms: linux/amd64,linux/arm64
+  build_on_merge:
+    if: github.event.pull_request.merged == true
+    uses: ./.github/workflows/docker-reusable-steps.yml
+    with:
+      checkout-ref: ${{ github.event.pull_request.merge_commit_sha }}
+      push: true
+    secrets:
+      registry-username: ${{ github.actor }}
+      registry-password: ${{ secrets.GITHUB_TOKEN }}
+  build_manual:
+    if: github.event_name == 'workflow_dispatch'
+    uses: ./.github/workflows/docker-reusable-steps.yml
+    with:
+      push: true
+    secrets:
+      registry-username: ${{ github.actor }}
+      registry-password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docker-reusable-steps.yml
+++ b/.github/workflows/docker-reusable-steps.yml
@@ -1,0 +1,84 @@
+name: Reusable Docker Build and Publish
+
+on:
+  workflow_call:
+    inputs:
+      checkout-ref:
+        description: "Git ref to checkout"
+        required: false
+        type: string
+        default: ""
+      push:
+        description: "Whether to push the image"
+        required: false
+        type: boolean
+        default: true
+      tags:
+        description: "Tag strategy for docker/metadata-action"
+        required: false
+        type: string
+        default: |
+          type=ref,event=branch
+          type=ref,event=pr
+          type=semver,pattern={{version}}
+          type=semver,pattern={{major}}.{{minor}}
+          type=semver,pattern={{major}}
+          type=sha
+      platforms:
+        description: "Platforms to build"
+        required: false
+        type: string
+        default: "linux/amd64,linux/arm64"
+    secrets:
+      registry-username:
+        description: "Registry username for login"
+        required: true
+      registry-password:
+        description: "Registry password or token for login"
+        required: true
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.checkout-ref }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to container registry
+        if: inputs.push
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.registry-username }}
+          password: ${{ secrets.registry-password }}
+
+      - name: Extract metadata for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: ${{ inputs.tags }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: ${{ inputs.push }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: ${{ inputs.platforms }}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,48 +1,30 @@
 name: Build and Publish NPM Package
 
 on:
-  push:
-    branches:
-      - main
-    tags:
-      - 'v*.*.*'
   pull_request:
     branches:
       - main
+    types: [closed]
   workflow_dispatch:
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
+  publish_on_merge:
+    if: github.event.pull_request.merged == true
+    uses: ./.github/workflows/npm-reusable-steps.yml
+    with:
+      checkout-ref: ${{ github.event.pull_request.merge_commit_sha }}
+      node-version: '20'
+      registry-url: 'https://npm.pkg.github.com'
+      scope: '@wilsonwong1990'
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}
 
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-          registry-url: 'https://npm.pkg.github.com'
-          scope: '@wilsonwong1990'
-
-      - name: Install dependencies
-        run: npm ci --legacy-peer-deps
-
-      - name: Run linter
-        run: npm run lint 2>/dev/null || echo "Linting skipped - no lint script or configuration found"
-
-      - name: Run tests
-        run: npm run test -- --run
-
-      - name: Build package
-        run: npm run build
-
-      - name: Publish to GitHub Packages
-        if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
-        run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  publish_manual:
+    if: github.event_name == 'workflow_dispatch'
+    uses: ./.github/workflows/npm-reusable-steps.yml
+    with:
+      node-version: '20'
+      registry-url: 'https://npm.pkg.github.com'
+      scope: '@wilsonwong1990'
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/npm-reusable-steps.yml
+++ b/.github/workflows/npm-reusable-steps.yml
@@ -1,0 +1,92 @@
+name: Reusable Build and Publish
+
+on:
+  workflow_call:
+    inputs:
+      checkout-ref:
+        description: "Git ref to checkout"
+        required: false
+        type: string
+        default: ""
+      node-version:
+        description: "Node.js version to use"
+        required: false
+        type: string
+        default: "20"
+      registry-url:
+        description: "Registry URL"
+        required: false
+        type: string
+        default: "https://npm.pkg.github.com"
+      scope:
+        description: "Package scope"
+        required: false
+        type: string
+        default: "@wilsonwong1990"
+      default-bump:
+        description: "Default bump type when no keywords found"
+        required: false
+        type: string
+        default: "patch"
+      version-type:
+        description: "Explicit bump override (major|minor|patch|prerelease|...)"
+        required: false
+        type: string
+        default: ""
+      tag-prefix:
+        description: "Prefix to use for git tags"
+        required: false
+        type: string
+        default: "v"
+    secrets:
+      token:
+        description: "Authentication token for npm publish"
+        required: true
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.checkout-ref }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ inputs.node-version }}
+          registry-url: ${{ inputs.registry-url }}
+          scope: ${{ inputs.scope }}
+
+      - name: Install dependencies
+        run: npm ci --legacy-peer-deps
+
+      - name: Run linter
+        run: npm run lint 2>/dev/null || echo "Linting skipped - no lint script or configuration found"
+
+      - name: Run tests
+        run: npm run test -- --run
+
+      - name: Build package
+        run: npm run build
+
+      - name: Automated version bump
+        id: bump
+        uses: phips28/gh-action-bump-version@v11.0.7
+        env:
+          GITHUB_TOKEN: ${{ secrets.token }}
+        with:
+          default: ${{ inputs.default-bump }}
+          version-type: ${{ inputs.version-type }}
+          tag-prefix: ${{ inputs.tag-prefix }}
+          commit-message: "chore: bump version to {{version}} [skip ci]"
+
+      - name: Publish package
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.token }}

--- a/.github/workflows/version-bump-suggestion.yml
+++ b/.github/workflows/version-bump-suggestion.yml
@@ -1,0 +1,193 @@
+name: Suggest Package Version Bump
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  workflow_dispatch:
+    inputs:
+      base-ref:
+        description: "Base branch or ref to compare against"
+        required: false
+        default: ""
+
+jobs:
+  suggest:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+
+    env:
+      DEFAULT_BASE: ${{ github.event.repository.default_branch }}
+      BASE_INPUT: ${{ github.event.inputs.base-ref || '' }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Determine base reference
+        id: base
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "branch=${{ github.event.pull_request.base.ref }}" >> "$GITHUB_OUTPUT"
+            echo "sha=${{ github.event.pull_request.base.sha }}" >> "$GITHUB_OUTPUT"
+          else
+            REF="$BASE_INPUT"
+            if [ -z "$REF" ]; then
+              REF="$DEFAULT_BASE"
+            fi
+            git fetch origin "$REF"
+            SHA=$(git rev-parse "origin/$REF")
+            echo "branch=$REF" >> "$GITHUB_OUTPUT"
+            echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Fetch base branch history
+        if: steps.base.outputs.branch
+        run: git fetch origin "${{ steps.base.outputs.branch }}"
+
+      - name: Analyze commits and suggest bump
+        id: suggest
+        env:
+          BASE_SHA: ${{ steps.base.outputs.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          npm install semver@7 --no-save >/dev/null 2>&1
+          node <<'EOF'
+          const fs = require('fs');
+          const { execSync } = require('child_process');
+
+          const baseSha = process.env.BASE_SHA;
+          const headSha = process.env.HEAD_SHA;
+
+          if (!fs.existsSync('package.json')) {
+            console.error('package.json not found');
+            process.exit(1);
+          }
+
+          const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+          const current = pkg.version;
+
+          function readLog(range) {
+            if (!range) return '';
+            try {
+              return execSync(`git log ${range} --pretty=format:%s%n%b`, { encoding: 'utf8' });
+            } catch (error) {
+              return '';
+            }
+          }
+
+          const range = baseSha ? `${baseSha}..${headSha}` : '';
+          const log = readLog(range);
+
+          const commits = log.split(/\n(?=\w)/).filter(Boolean);
+
+          let recommendation = 'patch';
+
+          const lines = log.split('\n');
+          for (const entry of lines) {
+            if (!entry) continue;
+            const header = entry.trim();
+            if (/BREAKING CHANGE/i.test(header) || /!:\s/.test(header)) {
+              recommendation = 'major';
+              break;
+            }
+            if (/^feat(\(|:)/i.test(header)) {
+              if (recommendation !== 'major') {
+                recommendation = 'minor';
+              }
+            }
+          }
+
+          const semver = require('semver');
+
+          let next = current;
+          if (semver.valid(current)) {
+            next = semver.inc(current, recommendation) || current;
+          } else {
+            const [major = '0', minor = '0', patch = '0'] = current.split('.');
+            const nums = [parseInt(major, 10) || 0, parseInt(minor, 10) || 0, parseInt(patch, 10) || 0];
+            if (recommendation === 'major') {
+              nums[0] += 1; nums[1] = 0; nums[2] = 0;
+            } else if (recommendation === 'minor') {
+              nums[1] += 1; nums[2] = 0;
+            } else {
+              nums[2] += 1;
+            }
+            next = nums.join('.');
+          }
+
+          const summary = {
+            recommendation,
+            current,
+            next,
+            commitCount: commits.length,
+          };
+
+          fs.appendFileSync(process.env.GITHUB_OUTPUT, `recommended=${summary.recommendation}\n`);
+          fs.appendFileSync(process.env.GITHUB_OUTPUT, `current=${summary.current}\n`);
+          fs.appendFileSync(process.env.GITHUB_OUTPUT, `next=${summary.next}\n`);
+          fs.appendFileSync(process.env.GITHUB_OUTPUT, `commit_count=${summary.commitCount}\n`);
+
+          console.log(summary);
+          EOF
+
+      - name: Update pull request comment
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        env:
+          RECOMMENDED: ${{ steps.suggest.outputs.recommended }}
+          CURRENT: ${{ steps.suggest.outputs.current }}
+          NEXT: ${{ steps.suggest.outputs.next }}
+          COMMITS: ${{ steps.suggest.outputs.commit_count }}
+        with:
+          script: |
+            const marker = '<!-- version-bump-suggestion -->';
+            const body = `${marker}
+            ### 📦 Suggested Version Bump
+
+            | Metric | Value |
+            | --- | --- |
+            | Current version | \
+` + process.env.CURRENT + ` |
+            | Recommended bump | ${process.env.RECOMMENDED || 'patch'} |
+            | Suggested next version | ${process.env.NEXT || 'N/A'} |
+            | Commits analyzed | ${process.env.COMMITS || '0'} |
+
+            > Tip: Update \`package.json\` to the suggested version (or adjust as needed) before merging.
+            `;
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              per_page: 100,
+            });
+
+            const existing = comments.find(comment => comment.body && comment.body.includes(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }
+
+      - name: Print suggestion summary
+        run: |
+          echo "Current version: ${{ steps.suggest.outputs.current }}"
+          echo "Recommended bump: ${{ steps.suggest.outputs.recommended }}"
+          echo "Suggested next version: ${{ steps.suggest.outputs.next }}"
+          echo "Commits analyzed: ${{ steps.suggest.outputs.commit_count }}"


### PR DESCRIPTION
This pull request refactors the CI/CD workflows for Docker and NPM publishing to use reusable workflow templates, streamlining maintenance and improving consistency. It also introduces an automated version bump suggestion workflow for NPM packages, which analyzes pull request commits and recommends the next semantic version directly in the PR comments.